### PR TITLE
Add starting GraphQL method

### DIFF
--- a/src/deliveryAPI.js
+++ b/src/deliveryAPI.js
@@ -74,6 +74,7 @@ class ContentDeliveryClientImpl {
       getAuthorizationHeaderValue: utils.bind(this.getAuthorizationHeaderValue, this),
       searchItems: utils.bind(this.queryItems, this),
       queryItems: utils.bind(this.queryItems, this),
+      graphQL: utils.bind(this.graphQL, this),
       getRenditionURL: utils.bind(this.getRenditionURL, this),
       getLayoutInfo: utils.bind(this.getLayoutInfo, this),
       getRecommendationResults: utils.bind(this.getRecommendationResults, this),
@@ -520,6 +521,34 @@ class ContentDeliveryClientImpl {
     );
 
     return self.restAPI.callRestServer(url, restCallArgs);
+  }
+
+  graphQL(params) {
+    const self = this;
+    const args = params || {};
+    const graphCallArgs = this.resolveRESTArgs('POST', args);
+    graphCallArgs.noCSRFToken = true;
+
+    logger.debug('ContentClient.queryItems: arguments');
+    logger.debug(args);
+
+    // no need for these search parameters
+    delete graphCallArgs.search
+
+    // format the query
+    graphCallArgs.postData = {
+      query: params.query || '',
+      variables: params.variables || ''
+    }
+    
+    // format the URL
+    // /content/published/api/v1.1/graphql
+    const url = self.restAPI.formatURL(
+      self.restAPI.resolveGraphQLPath(),
+      graphCallArgs,
+    );
+
+    return self.restAPI.callRestServer(url, graphCallArgs);
   }
 
   /**

--- a/src/managementAPI.js
+++ b/src/managementAPI.js
@@ -68,6 +68,7 @@ class ContentManagementClientImpl extends ContentDeliveryClientImpl {
       getItems: utils.bind(this.getItems, this),
       getAuthorizationHeaderValue: utils.bind(this.getAuthorizationHeaderValue, this),
       searchItems: utils.bind(this.queryItems, this),
+      graphQL: utils.bind(this.graphQL, this),
       queryItems: utils.bind(this.queryItems, this),
       getRenditionURL: utils.bind(this.getRenditionURL, this),
       getLayoutInfo: utils.bind(this.getLayoutInfo, this),

--- a/src/previewAPI.js
+++ b/src/previewAPI.js
@@ -64,6 +64,7 @@ class ContentPreviewClientImpl extends ContentDeliveryClientImpl {
       getItems: utils.bind(this.getItems, this),
       getAuthorizationHeaderValue: utils.bind(this.getAuthorizationHeaderValue, this),
       searchItems: utils.bind(this.queryItems, this),
+      graphQL: utils.bind(this.graphQL, this),
       queryItems: utils.bind(this.queryItems, this),
       getRenditionURL: utils.bind(this.getRenditionURL, this),
       getLayoutInfo: utils.bind(this.getLayoutInfo, this),

--- a/src/utils.js
+++ b/src/utils.js
@@ -964,6 +964,9 @@ class ContentApiV11Impl extends ContentApiV1Impl {
   resolveSearchPath(/* args */) {
     return '/items';
   }
+  resolveGraphQLPath(/* args */) {
+    return '/graphql';
+  }
 
   resolveGetBulkItemListPath(args) {
     // args.itemGUIDs: array of IDs to add to the URL


### PR DESCRIPTION
See [#5 SDK should support GraphQL](https://github.com/oracle/content-management-sdk/issues/5)

I wanted to change as little as possible, so this uses existing REST methods to perform GraphQL lookups.
